### PR TITLE
feat(config): adopt builder pattern for `FunPlusConfig`

### DIFF
--- a/FunPlusSDK/src/androidTest/java/com/funplus/sdk/FunPlusConfigTest.java
+++ b/FunPlusSDK/src/androidTest/java/com/funplus/sdk/FunPlusConfigTest.java
@@ -1,0 +1,160 @@
+package com.funplus.sdk;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.SmallTest;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Created by yuankun on 02/10/2016.
+ */
+
+@RunWith(AndroidJUnit4.class)
+@SmallTest
+public class FunPlusConfigTest {
+
+    private static final String APP_ID = "test";
+    private static final String APP_KEY = "funplus";
+    private static final String RUM_TAG = "test";
+    private static final String RUM_KEY = "funplus";
+    private static final SDKEnvironment ENV = SDKEnvironment.Sandbox;
+
+    private static final long DEFAULT_LOGGER_UPLOAD_INTERVAL = 60;
+    private static final long DEFAULT_RUM_UPLOAD_INTERVAL = 5;
+    private static final long DEFAULT_DATA_UPLOAD_INTERVAL = 5;
+    private static final double DEFAULT_RUM_SAMPLE_RATE = 1.0;
+
+    private Context context = InstrumentationRegistry.getContext();
+
+    @Test
+    public void testDefaultValuesForSandboxEnvironment() {
+        // Given, When
+        FunPlusConfig config = new FunPlusConfig(context, APP_ID, APP_KEY, RUM_TAG, RUM_KEY, ENV);
+
+        // Then
+        assertEquals(config.appId, APP_ID);
+        assertEquals(config.appKey, APP_KEY);
+        assertTrue(config.environment.equals(ENV));
+
+        assertEquals(config.loggerTag, RUM_TAG);
+        assertEquals(config.loggerKey, RUM_KEY);
+        assertEquals(config.logLevel, LogLevel.INFO);
+        assertEquals(config.loggerUploadInterval, DEFAULT_LOGGER_UPLOAD_INTERVAL);
+
+        assertEquals(config.rumTag, RUM_TAG);
+        assertEquals(config.rumKey, RUM_KEY);
+        assertEquals(config.rumUploadInterval, DEFAULT_RUM_UPLOAD_INTERVAL);
+
+        assertEquals(config.rumSampleRate, DEFAULT_RUM_SAMPLE_RATE, 0.001);
+        assertTrue(config.rumEventWhitelist.isEmpty());
+        assertTrue(config.rumUserWhitelist.isEmpty());
+        assertTrue(config.rumUserBlacklist.isEmpty());
+
+        assertEquals(config.dataTag, APP_ID);
+        assertEquals(config.dataKey, APP_KEY);
+        assertEquals(config.dataUploadInterval, DEFAULT_DATA_UPLOAD_INTERVAL);
+
+        assertTrue(config.dataAutoTraceSessionEvents);
+    }
+
+    @Test
+    public void testDefaultValuesForProductionEnvironment() {
+        // Given, When
+        FunPlusConfig config = new FunPlusConfig(context, APP_ID, APP_KEY, RUM_TAG, RUM_KEY, SDKEnvironment.Production);
+
+        // Then
+        assertEquals(config.appId, APP_ID);
+        assertEquals(config.appKey, APP_KEY);
+        assertTrue(config.environment.equals(SDKEnvironment.Production));
+
+        assertEquals(config.loggerTag, RUM_TAG);
+        assertEquals(config.loggerKey, RUM_KEY);
+        assertEquals(config.logLevel, LogLevel.ERROR);
+        assertEquals(config.loggerUploadInterval, 10 * 60);
+
+        assertEquals(config.rumTag, RUM_TAG);
+        assertEquals(config.rumKey, RUM_KEY);
+        assertEquals(config.rumUploadInterval, 10);
+
+        assertEquals(config.rumSampleRate, DEFAULT_RUM_SAMPLE_RATE, 0.001);
+        assertTrue(config.rumEventWhitelist.isEmpty());
+        assertTrue(config.rumUserWhitelist.isEmpty());
+        assertTrue(config.rumUserBlacklist.isEmpty());
+
+        assertEquals(config.dataTag, APP_ID);
+        assertEquals(config.dataKey, APP_KEY);
+        assertEquals(config.dataUploadInterval, 10);
+
+        assertTrue(config.dataAutoTraceSessionEvents);
+    }
+
+    @Test
+    public void testSettersChain() {
+        // Given
+        long loggerUploadInterval = 10;
+        long rumUploadInterval = 4;
+        long dataUploadInterval = 3;
+
+        double rumSampleRate = 0.8;
+
+        ArrayList<String> rumEventWhitelist = new ArrayList<>();
+        rumEventWhitelist.add("level_up");
+        rumEventWhitelist.add("money_gain");
+
+        ArrayList<String> rumUserWhitelist = new ArrayList<>();
+        rumUserWhitelist.add("user1");
+        rumUserWhitelist.add("user2");
+        rumUserWhitelist.add("user3");
+
+        ArrayList<String> rumUserBlacklist = new ArrayList<>();
+        rumUserBlacklist.add("user4");
+        rumUserBlacklist.add("user5");
+
+        FunPlusConfig config = new FunPlusConfig(context, APP_ID, APP_KEY, RUM_TAG, RUM_KEY, ENV);
+
+        // When
+        config.setLoggerUploadInterval(loggerUploadInterval)
+                .setRumUploadInterval(rumUploadInterval)
+                .setRumSampleRate(rumSampleRate)
+                .setRumEventWhitelist(rumEventWhitelist)
+                .setRumUserWhitelist(rumUserWhitelist)
+                .setRumUserBlacklist(rumUserBlacklist)
+                .setDataUploadInterval(dataUploadInterval)
+                .setDataAutoTraceSessionEvents(false)
+                .end();
+
+        // Then
+        assertEquals(config.appId, APP_ID);
+        assertEquals(config.appKey, APP_KEY);
+        assertTrue(config.environment.equals(ENV));
+
+        assertEquals(config.loggerTag, RUM_TAG);
+        assertEquals(config.loggerKey, RUM_KEY);
+        assertEquals(config.logLevel, LogLevel.INFO);
+        assertEquals(config.loggerUploadInterval, loggerUploadInterval);
+
+        assertEquals(config.rumTag, RUM_TAG);
+        assertEquals(config.rumKey, RUM_KEY);
+        assertEquals(config.rumUploadInterval, rumUploadInterval);
+
+        assertEquals(config.rumSampleRate, rumSampleRate, 0.001);
+        assertEquals(config.rumEventWhitelist.size(), 2);
+        assertEquals(config.rumUserWhitelist.size(), 3);
+        assertEquals(config.rumUserBlacklist.size(), 2);
+
+        assertEquals(config.dataTag, APP_ID);
+        assertEquals(config.dataKey, APP_KEY);
+        assertEquals(config.dataUploadInterval, dataUploadInterval);
+
+        assertFalse(config.dataAutoTraceSessionEvents);
+    }
+}

--- a/FunPlusSDK/src/main/java/com/funplus/sdk/FunPlusConfig.java
+++ b/FunPlusSDK/src/main/java/com/funplus/sdk/FunPlusConfig.java
@@ -23,24 +23,26 @@ public class FunPlusConfig {
     @NonNull final String loggerTag;
     @NonNull final String loggerKey;
     @NonNull final LogLevel logLevel;
-    final long loggerUploadInterval;
+    long loggerUploadInterval;
 
     @NonNull final String rumEndpoint;
     @NonNull final String rumTag;
     @NonNull final String rumKey;
-    final long rumUploadInterval;
+    long rumUploadInterval;
 
-    final double rumSampleRate;
-    @NonNull final List<String> rumEventWhitelist;
-    @NonNull final List<String> rumUserWhitelist;
-    @NonNull final List<String> rumUserBlacklist;
+    double rumSampleRate;
+    @NonNull List<String> rumEventWhitelist;
+    @NonNull List<String> rumUserWhitelist;
+    @NonNull List<String> rumUserBlacklist;
 
     @NonNull final String dataEndpoint;
     @NonNull final String dataTag;
     @NonNull final String dataKey;
-    final long dataUploadInterval;
+    long dataUploadInterval;
 
-    FunPlusConfig(@NonNull Context context,
+    boolean dataAutoTraceSessionEvents;
+
+    public FunPlusConfig(@NonNull Context context,
                   @NonNull String appId,
                   @NonNull String appKey,
                   @NonNull String rumTag,
@@ -73,6 +75,8 @@ public class FunPlusConfig {
         this.dataTag = appId;
         this.dataKey = appKey;
         this.dataUploadInterval = environment == SDKEnvironment.Sandbox ? 5 : 10;
+
+        dataAutoTraceSessionEvents = true;
     }
 
     @Deprecated
@@ -129,5 +133,55 @@ public class FunPlusConfig {
         dataTag = configDict.getString("data_tag");
         dataKey = configDict.getString("data_key");
         dataUploadInterval = configDict.has("data_upload_interval") ? configDict.getLong("data_upload_interval") : 10;
+
+        dataAutoTraceSessionEvents = true;
+    }
+
+    public FunPlusConfig setLoggerUploadInterval(long value) {
+        loggerUploadInterval = value;
+        return this;
+    }
+
+    public FunPlusConfig setRumUploadInterval(long value) {
+        rumUploadInterval = value;
+        return this;
+    }
+
+    public FunPlusConfig setRumSampleRate(double value) {
+        rumSampleRate = value;
+        return this;
+    }
+
+    public FunPlusConfig setRumEventWhitelist(@NonNull List<String> value) {
+        rumEventWhitelist = value;
+        return this;
+    }
+
+    public FunPlusConfig setRumUserWhitelist(@NonNull List<String> value) {
+        rumUserWhitelist = value;
+        return this;
+    }
+
+    public FunPlusConfig setRumUserBlacklist(@NonNull List<String> value) {
+        rumUserBlacklist = value;
+        return this;
+    }
+
+    public FunPlusConfig setDataUploadInterval(long value) {
+        dataUploadInterval = value;
+        return this;
+    }
+
+    public FunPlusConfig setDataAutoTraceSessionEvents(boolean value) {
+        dataAutoTraceSessionEvents = value;
+        return this;
+    }
+
+    /**
+     * This method should be called at the end of the settings chain.
+     * It is just a stub.
+     */
+    public void end() {
+        // Do nothing
     }
 }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   * [Add Permissions](#add-permissions)
   * [Add Broadcast Receiver](#add-broadcast-receiver)
   * [Install the SDK](#install-the-sdk)
+  * [Config the SDK](#config-the-sdk)
 * [Usage](#usage)
   * [The ID Module](#the-id-module)
     * [Get an FPID Based on a Given User ID](get-an-fpid-based-on-a-given-user-id)
@@ -92,6 +93,44 @@ SDKEnvironment env = SDKEnvironment.Production;		// Production/Sandbox
 FunPlusSDK.install(context, appId, appKey, rumTag, rumKey, env);
 FunPlusSDK.registerActivityLifecycleCallbacks(application);
 ```
+
+### Config the SDK
+
+You may want to override SDK's default config values. In such a case, you need to initialize the SDK in a different way, as the following code snippet illustrates.
+
+```java
+import com.funplus.sdk.FunPlusSDK;
+import com.funplus.sdk.SDKEnvironment;
+
+Application application = "{YourApplicationInstance}";
+Context context = "{YourAppContext}";
+String appId = "{YourAppId}";
+String appKey = "{YourAppKey}";
+String rumTag = "{YourRumTag}";
+String rumKey = "{YourRumKey}";
+SDKEnvironment env = SDKEnvironment.Production;		// Production/Sandbox
+
+FunPlusConfig funPlusConfig = new FunPlusConfig(context, appId, appKey, rumTag, rumKey, env);
+
+funPlusConfig.setRumUploadInterval(10)
+  			.setDataAutoTraceSessionEvents(false)
+  			.end();
+
+FunPlusSDK.install(funPlusConfig);
+FunPlusSDK.registerActivityLifecycleCallbacks(application);
+```
+
+Here's all the config values that can be overrided.
+
+| name                       | type     | description                              |
+| -------------------------- | -------- | ---------------------------------------- |
+| rumUploadInterval          | Int64    | This value indicates a time interval to trigger a RUM events uploading process. Default is 30. |
+| rumSampleRate              | Double   | This value indicates percentage of RUM events to be traced for sampling. Default is 1.0. |
+| rumEventWhitelist          | [String] | RUM events in this array will always be traced. Default is an empty array. |
+| rumUserWhitelist           | [String] | RUM events produced by users in this array will always be traced. Default is an empty array. |
+| rumUserBlacklist           | [String] | RUM events produced by users in this array will never be traced. `rumUesrWhitelist` will be checked before this array. Default is an empty array. |
+| dataUploadInterval         | Int64    | This value indicates a time interval to trigger a Data events uploading process. Default is 30. |
+| dataAutoTraceSessionEvents | Bool     | If set true, SDK will automatically trace `session_start` and `session_end` events. Default is true. |
 
 ## Usage
 


### PR DESCRIPTION
In order to override SDK's default config values, a builder pattern is
introduced. Developer creates a new `FunPlusConfig` object and overrides
some config values, then uses this object to initialize the SDK.

Here's an example:

```
import com.funplus.sdk.FunPlusSDK;
import com.funplus.sdk.SDKEnvironment;

Application application = "{YourApplicationInstance}";
Context context = "{YourAppContext}";
String appId = "{YourAppId}";
String appKey = "{YourAppKey}";
String rumTag = "{YourRumTag}";
String rumKey = "{YourRumKey}";
SDKEnvironment env = SDKEnvironment.Production;        // Production/Sandbox

FunPlusConfig funPlusConfig = new FunPlusConfig(context, appId, appKey, rumTag, rumKey, env);

funPlusConfig.setRumUploadInterval(10)
              .setDataAutoTraceSessionEvents(false)
              .end();

FunPlusSDK.install(funPlusConfig);
FunPlusSDK.registerActivityLifecycleCallbacks(application);
```

Closes #6