### PR TITLE
feat(data): ability to turn off auto tracing of session events

### DIFF
--- a/FunPlusSDK/src/main/java/com/funplus/sdk/FunPlusData.java
+++ b/FunPlusSDK/src/main/java/com/funplus/sdk/FunPlusData.java
@@ -74,7 +74,9 @@ public class FunPlusData implements IFunPlusData, SessionStatusChangeListener {
             }
         }
 
-        FunPlusFactory.getSessionManager(funPlusConfig).registerListener(this);
+        if (funPlusConfig.dataAutoTraceSessionEvents) {
+            FunPlusFactory.getSessionManager(funPlusConfig).registerListener(this);
+        }
 
         Log.i(LOG_TAG, "FunPlusData ready to work");
     }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
   * [The Data Module](#the-data-module)
     - [Trace Custom Events](#trace-custom-events)
     - [Set Extra Properties to Data Events](#set-extra-properties-to-data-events)
+    - [Manually trace session events](#manually-trace-session-events)
 * [FAQ](#faq)
 
 ## Integration
@@ -282,6 +283,20 @@ FunPlusSDK.getFunPlusData().eraseExtraProperty(key);
 ```
 
 Keep in mind that a second calling of the `setExtraProperty()` method will override the previous set value.
+
+#### Manually trace session events
+
+By default, SDK automatically traces the `session_start` and `session_end` events. This behavior can be changed by override the `dataAutoTraceSessionEvents` config value to false.
+
+Then you need to manually trace these events.
+
+```java
+FunPlusSDK.getFunPlusData().traceSessionStart();
+...
+FunPlusSDK.getFunPlusData().traceSessionEnd(long sessionLength);
+```
+
+Note that don't manually trace these events when `dataAutoTraceSessionEvents` is set to true.
 
 ## FAQ
 


### PR DESCRIPTION
If `dataAutoTraceSessionEvents` is set to false, SDK will not
automatically trace session events. Developer needs to trace
these events manually:

```
FunPlusSDK.getFunPlusData().traceSessionStart();
...
FunPlusSDK.getFunPlusData().traceSessionEnd(long sessionLength);
```

Closes #5