### PR TITLE
bug(data): allow `null` for `product_name` and `product_type`

### DIFF
--- a/FunPlusSDK/src/main/java/com/funplus/sdk/FunPlusData.java
+++ b/FunPlusSDK/src/main/java/com/funplus/sdk/FunPlusData.java
@@ -158,12 +158,15 @@ public class FunPlusData implements IFunPlusData, SessionStatusChangeListener {
     public void tracePayment(double amount,
                              @NonNull String currency,
                              @NonNull String productId,
-                             @NonNull String productName,
-                             @NonNull String productType,
+                             @Nullable String productName,
+                             @Nullable String productType,
                              @NonNull String transactionId,
                              @NonNull String paymentProcessor,
                              @NonNull String itemsReceived,
                              @NonNull String currencyReceived) {
+        productName = (productName == null) ? "" : productName;
+        productType = (productType == null) ? "" : productType;
+
         try {
             JSONObject customProperties = new JSONObject();
             customProperties.put("amount", amount);


### PR DESCRIPTION
Modify `FunPlusData.tracePayment()` to allow `null` values
for these two parameters: `product_name` and `product_type`.

Closes #19