### PR TITLE
refactor(data): allow null or "" for payment event parameter

### DIFF
--- a/FunPlusSDK/src/main/java/com/funplus/sdk/FunPlusData.java
+++ b/FunPlusSDK/src/main/java/com/funplus/sdk/FunPlusData.java
@@ -162,10 +162,29 @@ public class FunPlusData implements IFunPlusData, SessionStatusChangeListener {
                              @Nullable String productType,
                              @NonNull String transactionId,
                              @NonNull String paymentProcessor,
-                             @NonNull String itemsReceived,
-                             @NonNull String currencyReceived) {
+                             @Nullable String itemsReceived,
+                             @Nullable String currencyReceived) {
         productName = (productName == null) ? "" : productName;
         productType = (productType == null) ? "" : productType;
+
+        itemsReceived = (itemsReceived == null || itemsReceived.isEmpty()) ? "[]" : itemsReceived;
+        currencyReceived = (currencyReceived == null || currencyReceived.isEmpty()) ? "[]" : currencyReceived;
+
+        // Init with empty JSON arrays.
+        JSONArray cItemsReceived = new JSONArray();
+        JSONArray cCurrencyReceived = new JSONArray();
+
+        try {
+            cItemsReceived = new JSONArray(itemsReceived);
+        } catch (JSONException e) {
+            getLogger().e("Error parsing parameter: `itemsReceived`");
+        }
+
+        try {
+            cCurrencyReceived = new JSONArray(currencyReceived);
+        } catch (JSONException e) {
+            getLogger().e("Error parsing parameter: `currencyReceived`");
+        }
 
         try {
             JSONObject customProperties = new JSONObject();
@@ -176,8 +195,8 @@ public class FunPlusData implements IFunPlusData, SessionStatusChangeListener {
             customProperties.put("iap_product_type", productType);
             customProperties.put("transaction_id", transactionId);
             customProperties.put("payment_processor", paymentProcessor);
-            customProperties.put("c_items_received", new JSONArray(itemsReceived));
-            customProperties.put("c_currency_received", new JSONArray(currencyReceived));
+            customProperties.put("c_items_received", cItemsReceived);
+            customProperties.put("c_currency_received", cCurrencyReceived);
 
             trace(DataEventType.Kpi, buildDataEvent("payment", customProperties));
         } catch (JSONException e) {

--- a/README.md
+++ b/README.md
@@ -270,18 +270,18 @@ class FunPlusData {...
     params productType:        The type of the product purchased (optional).
     params transactionId:      The unique transaction ID sent back by the payment processor.
     params paymentProcessor:   The payment processor.
-    params itemsReceived:      A string of JSON array, consisting of one or more items received.
-    params currencyReceived:   A string of JSON array, consisting one or more types of currency received.
+    params itemsReceived:      A string of JSON array, consisting of one or more items received (optional).
+    params currencyReceived:   A string of JSON array, consisting one or more types of currency received (optional).
  */
 public void tracePayment(double amount,
-                         String currency,
-                         String productId,
-                         String productName,
-                         String productType,
-                         String transactionId,
-                         String paymentProcessor,
-                         String itemsReceived,
-                         String currencyReceived);
+                         @NonNull String currency,
+                         @NonNull String productId,
+                         @Nullable String productName,
+                         @Nullable String productType,
+                         @NonNull String transactionId,
+                         @NonNull String paymentProcessor,
+                         @Nullable String itemsReceived,
+                         @Nullable String currencyReceived);
 ```
 
 The `itemsReceived` parameter contains one or more items received. It consists of the following required fields:


### PR DESCRIPTION
It's handy to allow null or empty values for the two parameters
in `FunPlusData.tracePayment()`:

- `itemsReceived`
- `currencyReceived`

Closes #23